### PR TITLE
Address webhint issues regarding Accessibility, Development, Other, PWA

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -33,7 +33,6 @@ class Navbar extends Component {
     return (
       <nav
         className="navbar is-vertical-spaced is-transparent"
-        role="navigation"
         aria-label="main navigation"
       >
         <div className="navbar-brand">
@@ -65,10 +64,10 @@ class Navbar extends Component {
               to="https://www.facebook.com/horchatajs/"
               className="navbar-item"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               <figure className="image is-16x16">
-                <img src={facebook} />
+                <img src={facebook} alt='Facebook'/>
               </figure>
             </ExternalLink>
             <ExternalLink
@@ -76,10 +75,10 @@ class Navbar extends Component {
               to="https://twitter.com/HorchataJS"
               className="navbar-item"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               <figure className="image is-16x16">
-                <img src={twitter} />
+                <img src={twitter} alt='Twitter'/>
               </figure>
             </ExternalLink>
             <ExternalLink
@@ -87,10 +86,10 @@ class Navbar extends Component {
               to="https://www.instagram.com/horchatajs/"
               className="navbar-item"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               <figure className="image is-16x16">
-                <img src={instagram} />
+                <img src={instagram} alt='Instagram'/>
               </figure>
             </ExternalLink>
             <ExternalLink
@@ -98,10 +97,10 @@ class Navbar extends Component {
               to="https://github.com/horchatajs"
               className="navbar-item"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               <figure className="image is-16x16">
-                <img src={github} />
+                <img src={github} alt='Github'/>
               </figure>
             </ExternalLink>
           </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,6 +26,7 @@ const IndexPage = props => {
     <div>
       <Helmet>
         <title>{`${site.title} – ${site.description}`}</title>
+        <html lang="es" />
       </Helmet>
       <section className="section has-text-centered">
         <h1 className="title is-1 has-text-black has-text-weight-bold">
@@ -36,7 +37,7 @@ const IndexPage = props => {
           to="https://www.meetup.com/es-ES/horchatajs/"
           className="button is-primary is-large has-text-black"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
         >
           <span>
             Registrate{' '}
@@ -63,7 +64,7 @@ const IndexPage = props => {
                   eventLabel="Link código de conducta"
                   to="https://github.com/devs-sv/codigo-de-conducta"
                   target="_blank"
-                  rel="noopener"
+                  rel="noopener noreferrer"
                 >
                   {' '}
                   código de conducta de la comunidad
@@ -92,7 +93,7 @@ const IndexPage = props => {
                 to="https://github.com/horchatajs/charlas"
                 className="button is-black is-outlined"
                 target="_blank"
-                rel="noopener"
+                rel="noopener noreferrer"
               >
                 <span>Información de charlas</span>
               </ExternalLink>
@@ -106,6 +107,7 @@ const IndexPage = props => {
                 <ExternalLink
                   eventLabel="Link Slack texto"
                   to="http://slack.horchatajs.com/"
+                  rel='noopener noreferrer'
                 >
                   Slack
                 </ExternalLink>{' '}
@@ -132,10 +134,10 @@ const IndexPage = props => {
               </p>
               <ExternalLink
                 eventLabel="Link patrocinio"
-                to="mailto:horchatajs@gmail.com?subject=Quiero patrocinar un evento de HorchataJS"
+                to="mailto:horchatajs@gmail.com?subject=Quiero%20patrocinar%20un%20evento%20de%20HorchataJS"
                 className="button is-black is-outlined"
                 target="_blank"
-                rel="noopener"
+                rel="noopener noreferrer"
               >
                 <span>Contacto sobre patrocinios</span>
               </ExternalLink>
@@ -143,20 +145,20 @@ const IndexPage = props => {
           </div>
         </div>
       </section>
-      <section className="section has-text-centered">
+      <div className="section has-text-centered">
         <ExternalLink
           eventLabel="Link Slack botón"
           to="http://slack.horchatajs.com/"
           className="button is-primary is-outlined is-medium has-text-black"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
         >
           <figure className="image is-24x24" style={{ marginRight: 10 }}>
-            <img src={slack} />
+            <img src={slack} alt='Slack'/>
           </figure>
           <span>slack.horchatajs.com</span>
         </ExternalLink>
-      </section>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# What does this PR do
Addresses 9 warnings and 19 errors from webhint analysis

# Demo

## Before:
![image](https://user-images.githubusercontent.com/1679438/46326572-9e95b380-c5ba-11e8-8f25-396cf1f6a64b.png)

## After
![image](https://user-images.githubusercontent.com/1679438/46326656-08ae5880-c5bb-11e8-9e69-72e031c05706.png)

# Aditional details 
The majority of warnings can't be dealt with due to the scaffolded code from Gatsby. Unless the Gatsby team decides to tackle those warnings themselves, we will keep having them.
